### PR TITLE
Improve the config validation

### DIFF
--- a/src/ServiceContainer/Psr7Extension.php
+++ b/src/ServiceContainer/Psr7Extension.php
@@ -62,7 +62,7 @@ final class Psr7Extension implements Extension
     {
         $builder
             ->children()
-                ->scalarNode('app')
+                ->scalarNode('app')->isRequired()->end()
             ->end()
         ->end();
     }


### PR DESCRIPTION
- properly end the scalarNode so that the indentation of `->end()` calls is not confusing
- mark the node as required, so that the code assuming that `$config['app']` is configured is safe.