### PR TITLE
Localise responsibility for app reloading into one place

### DIFF
--- a/src/AppFile/Loader.php
+++ b/src/AppFile/Loader.php
@@ -12,16 +12,18 @@ use Cjm\Behat\Psr7Extension\Psr7AppLoader;
  */
 class Loader implements Psr7AppLoader
 {
+    private $path;
     private $factories;
 
-    public function __construct(Psr7AppFactory ...$factories)
+    public function __construct(string $path, Psr7AppFactory ...$factories)
     {
         $this->factories = $factories;
+        $this->path = $path;
     }
 
-    public function load(string $path): Psr7App
+    public function load(): Psr7App
     {
-        $type = $this->loadFromFile($path);
+        $type = $this->loadFromFile($this->path);
 
         foreach ($this->factories as $factory) {
             if ($app = $factory->createFrom($type)) {

--- a/src/CachingLoader.php
+++ b/src/CachingLoader.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Cjm\Behat\Psr7Extension;
+
+class CachingLoader implements Psr7AppLoader
+{
+    private $loader;
+    private $app;
+
+    public function __construct(Psr7AppLoader $loader)
+    {
+        $this->loader = $loader;
+    }
+
+    public function load(): Psr7App
+    {
+        return $this->app ?: ($this->app = $this->loader->load());
+    }
+}

--- a/src/Psr7AppLoader.php
+++ b/src/Psr7AppLoader.php
@@ -8,5 +8,5 @@ namespace Cjm\Behat\Psr7Extension;
  */
 interface Psr7AppLoader
 {
-    public function load(string $config) : Psr7App;
+    public function load() : Psr7App;
 }

--- a/src/ServiceContainer/services.yml
+++ b/src/ServiceContainer/services.yml
@@ -12,12 +12,8 @@ services:
   cjm.behat.psr7.kernel:
     class: Cjm\Behat\Psr7Extension\SymfonyKernel
     arguments:
-      - "@cjm.behat.psr7.app"
+      - "@cjm.behat.psr7.loader"
       - "@cjm.behat.psr7.http_message_bridge.converter"
-
-  cjm.behat.psr7.app:
-    class: Cjm\Behat\Psr7Extension\Psr7App
-    factory: "cjm.behat.psr7.loader:load"
 
   cjm.behat.psr7.loader:
     class: Cjm\Behat\Psr7Extension\AppFile\Loader

--- a/src/ServiceContainer/services.yml
+++ b/src/ServiceContainer/services.yml
@@ -18,12 +18,11 @@ services:
   cjm.behat.psr7.app:
     class: Cjm\Behat\Psr7Extension\Psr7App
     factory: "cjm.behat.psr7.loader:load"
-    arguments:
-      - "%cjm.behat.psr7.app%"
 
   cjm.behat.psr7.loader:
     class: Cjm\Behat\Psr7Extension\AppFile\Loader
-    arguments: [] # receives services tagged as cjm.behat.psr7.factory
+    arguments:
+      - "%cjm.behat.psr7.app%" # also receives services tagged as cjm.behat.psr7.factory
 
   cjm.behat.psr7.factory.callback:
     class: Cjm\Behat\Psr7Extension\Callback\AppFactory

--- a/src/ServiceContainer/services.yml
+++ b/src/ServiceContainer/services.yml
@@ -20,6 +20,12 @@ services:
     arguments:
       - "%cjm.behat.psr7.app%" # also receives services tagged as cjm.behat.psr7.factory
 
+  cjm.behat.psr7.caching_loader:
+    class: Cjm\Behat\Psr7Extension\CachingLoader
+    decorates: "cjm.behat.psr7.loader"
+    arguments:
+      - "@cjm.behat.psr7.caching_loader.inner"
+
   cjm.behat.psr7.factory.callback:
     class: Cjm\Behat\Psr7Extension\Callback\AppFactory
     tags:

--- a/src/SymfonyKernel.php
+++ b/src/SymfonyKernel.php
@@ -14,13 +14,13 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 final class SymfonyKernel implements HttpKernelInterface
 {
-    private $app;
     private $converter;
+    private $loader;
 
     public function __construct(Psr7AppLoader $loader, SymfonyToPsr7Converter $converter)
     {
-        $this->app = $loader->load();
         $this->converter = $converter;
+        $this->loader = $loader;
     }
 
     /**
@@ -29,7 +29,7 @@ final class SymfonyKernel implements HttpKernelInterface
     public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
     {
         return $this->converter->convertResponse(
-            $this->app->handle(
+            $this->loader->load()->handle(
                 $this->converter->convertRequest($request)
             )
         );

--- a/src/SymfonyKernel.php
+++ b/src/SymfonyKernel.php
@@ -17,9 +17,9 @@ final class SymfonyKernel implements HttpKernelInterface
     private $app;
     private $converter;
 
-    public function __construct(Psr7App $app, SymfonyToPsr7Converter $converter)
+    public function __construct(Psr7AppLoader $loader, SymfonyToPsr7Converter $converter)
     {
-        $this->app = $app;
+        $this->app = $loader->load();
         $this->converter = $converter;
     }
 

--- a/tests/AppFile/LoaderTest.php
+++ b/tests/AppFile/LoaderTest.php
@@ -15,6 +15,7 @@ class LoaderTest extends TestCase
     function setUp()
     {
         $this->loader = new Loader(
+            self::TMP_APP_FILE,
             $this->createMock(Psr7AppFactory::class)
         );
     }
@@ -23,7 +24,7 @@ class LoaderTest extends TestCase
     {
         $this->expectException(FileNotFound::class);
 
-        $this->loader->load(self::TMP_APP_FILE);
+        $this->loader->load();
     }
 
     function testItThrowsExceptionIfFileDoesNotReturn()
@@ -32,7 +33,7 @@ class LoaderTest extends TestCase
 
         file_put_contents(self::TMP_APP_FILE, '<?php ');
 
-        $this->loader->load(self::TMP_APP_FILE);
+        $this->loader->load();
     }
 
     function testItThrowsExceptionIfNoFactoryCanMakeApp()
@@ -41,12 +42,13 @@ class LoaderTest extends TestCase
 
         $this->expectException(UnknownType::class);
 
-        $this->loader->load(self::TMP_APP_FILE);
+        $this->loader->load();
     }
 
     function testItCreatesAnAppIfAFactoryCan()
     {
         $this->loader = new Loader(
+            self::TMP_APP_FILE,
             $factory1 = $this->createMock(Psr7AppFactory::class),
             $factory2 = $this->createMock(Psr7AppFactory::class)
         );
@@ -56,7 +58,7 @@ class LoaderTest extends TestCase
 
         $factory2->method('createFrom')->willReturn($app);
 
-        $this->assertSame($app, $this->loader->load(self::TMP_APP_FILE));
+        $this->assertSame($app, $this->loader->load());
     }
 
     function tearDown()

--- a/tests/CachingLoaderTest.php
+++ b/tests/CachingLoaderTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Cjm\Behat\Psr7Extension;
+
+use PHPUnit\Framework\TestCase;
+
+class CachingLoaderTest extends TestCase
+{
+    private $innerLoader;
+    private $innerApp;
+    private $loader;
+
+    public function setUp()
+    {
+        $this->innerLoader = $this->createMock(Psr7AppLoader::class);
+        $this->innerApp = $this->createMock(Psr7App::class);
+
+        $this->innerLoader->method('load')->willReturn($this->innerApp);
+
+        $this->loader = new CachingLoader($this->innerLoader);
+    }
+
+    public function testItLoadsTheApp()
+    {
+        $app = $this->loader->load();
+
+        $this->assertSame($this->innerApp, $app);
+    }
+
+    public function testItOnlyLoadsTheAppOnce()
+    {
+        $this->innerLoader
+             ->expects($this->once())
+             ->method('load');
+
+        $this->loader->load();
+        $app = $this->loader->load();
+
+        $this->assertSame($this->innerApp, $app);
+    }
+}


### PR DESCRIPTION
Because we may need to look at #8 at some point, possibly via config, I've refactored so there is a class (`CachingLoader`) that is responsible for explicitly only loading the config once.